### PR TITLE
Fix: Resolve frame drop issues in video compression and frame reduction

### DIFF
--- a/Sources/FYVideoCompressor/FYVideoCompressor.swift
+++ b/Sources/FYVideoCompressor/FYVideoCompressor.swift
@@ -183,7 +183,8 @@ public class FYVideoCompressor {
         
         let videoSettings = createVideoSettingsWithBitrate(targetVideoBitrate,
                                                            maxKeyFrameInterval: 10,
-                                                           size: scaleSize)
+                                                           size: scaleSize,
+                                                           targetFPS: quality.value.fps)
 #if DEBUG
         print("************** Video info **************")
 #endif
@@ -256,7 +257,8 @@ public class FYVideoCompressor {
         let targetSize = calculateSizeWithScale(config.scale, originalSize: videoTrack.naturalSize)
         let videoSettings = createVideoSettingsWithBitrate(targetVideoBitrate,
                                                            maxKeyFrameInterval: config.videomaxKeyFrameInterval,
-                                                           size: targetSize)
+                                                           size: targetSize,
+                                                           targetFPS: config.fps)
         
         var audioTrack: AVAssetTrack?
         var audioSettings: [String: Any]?
@@ -457,11 +459,12 @@ public class FYVideoCompressor {
         
     }
     
-    private func createVideoSettingsWithBitrate(_ bitrate: Float, maxKeyFrameInterval: Int, size: CGSize) -> [String: Any] {
+    private func createVideoSettingsWithBitrate(_ bitrate: Float, maxKeyFrameInterval: Int, size: CGSize, targetFPS: Float = 30) -> [String: Any] {
         return [AVVideoCodecKey: AVVideoCodecType.h264,
                 AVVideoWidthKey: size.width,
                AVVideoHeightKey: size.height,
           AVVideoScalingModeKey: AVVideoScalingModeResizeAspectFill,
+          AVVideoExpectedSourceFrameRateKey: targetFPS,
 AVVideoCompressionPropertiesKey: [AVVideoAverageBitRateKey: bitrate,
                                     AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
                                  AVVideoH264EntropyModeKey: AVVideoH264EntropyModeCABAC,

--- a/Sources/FYVideoCompressor/VideoFrameReducer.swift
+++ b/Sources/FYVideoCompressor/VideoFrameReducer.swift
@@ -29,14 +29,16 @@ public struct ReduceFrameEvenlySpaced: VideoFrameReducer {
         let originalFrames = (0..<Int(originalFPS * videoDuration)).map({ $0 })
         
         var res = [Int]()
-        
-        while res.count < Int(targetFPS * videoDuration) {
+
+        while res.count < Int(originalFPS * videoDuration) && counter * stride < originalFrames.count {
             let index = counter * stride
-            let frame = originalFrames[index]
-            res.append(frame)
+            if index < originalFrames.count {
+                let frame = originalFrames[index]
+                res.append(frame)
+            }
             counter += 1
         }
-        
+
         return res
     }
 }


### PR DESCRIPTION
1. Updated the `reduce` method in `ReduceFrameEvenlySpaced` to use `originalFPS * videoDuration` for loop condition and index checks, preventing frame drop by ensuring all frames are correctly processed.
2. Altered video compression settings in `createVideoSettingsWithBitrate` to accurately use `targetFPS`, enhancing the frame rate consistency during compression.

These changes collectively resolve the previously observed frame drop issue, ensuring a more reliable and accurate frame reduction in FYVideoCompressor.